### PR TITLE
Add Python desktop client skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+MyLora/
+__pycache__/
+*.pyc

--- a/desktop_app/README.md
+++ b/desktop_app/README.md
@@ -1,0 +1,16 @@
+# MyLoRA Desktop Client
+
+This folder contains a simple Tkinter based client for interacting with the MyLoRA REST API.
+
+## Usage
+
+1. Install the requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python main.py
+   ```
+
+Set the `MYLORA_API_URL` environment variable to point to a different server. The default is `http://localhost:5000`.

--- a/desktop_app/api.py
+++ b/desktop_app/api.py
@@ -1,0 +1,29 @@
+"""Wrapper functions for the MyLoRA REST API."""
+
+from urllib.parse import urljoin
+import requests
+
+import config
+
+
+def _request(path: str, params=None):
+    url = urljoin(config.API_BASE_URL + '/', path.lstrip('/'))
+    resp = requests.get(url, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def search(query: str, limit: int | None = None, offset: int = 0):
+    params = {"query": query, "limit": limit, "offset": offset}
+    return _request('search', params)
+
+
+def grid_data(q: str = '*', category: int | None = None, offset: int = 0, limit: int = 50):
+    params = {"q": q, "offset": offset, "limit": limit}
+    if category is not None:
+        params["category"] = category
+    return _request('grid_data', params)
+
+
+def categories():
+    return _request('categories')

--- a/desktop_app/config.py
+++ b/desktop_app/config.py
@@ -1,0 +1,4 @@
+import os
+
+# Base URL of the MyLora API server
+API_BASE_URL = os.environ.get('MYLORA_API_URL', 'http://localhost:5000')

--- a/desktop_app/main.py
+++ b/desktop_app/main.py
@@ -1,0 +1,51 @@
+"""Basic Tkinter client for the MyLoRA API."""
+
+from tkinter import Tk, Listbox, Entry, Button, Label, END, Scrollbar, RIGHT, Y
+from threading import Thread
+import api
+
+
+class App(Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("MyLoRA Desktop")
+        self.geometry("600x400")
+
+        self.search_entry = Entry(self)
+        self.search_entry.pack(fill='x', padx=5, pady=5)
+
+        self.search_btn = Button(self, text="Search", command=self.load_data)
+        self.search_btn.pack(pady=5)
+
+        scrollbar = Scrollbar(self)
+        scrollbar.pack(side=RIGHT, fill=Y)
+
+        self.listbox = Listbox(self, yscrollcommand=scrollbar.set)
+        self.listbox.pack(expand=True, fill='both', padx=5, pady=5)
+        scrollbar.config(command=self.listbox.yview)
+
+        self.status = Label(self, text="", anchor='w')
+        self.status.pack(fill='x')
+
+        self.after(100, self.load_data)
+
+    def load_data(self):
+        query = self.search_entry.get() or '*'
+        self.status.config(text="Loading...")
+        Thread(target=self._fetch_and_populate, args=(query,)).start()
+
+    def _fetch_and_populate(self, query: str):
+        try:
+            entries = api.grid_data(q=query)
+            self.listbox.delete(0, END)
+            for entry in entries:
+                name = entry.get('name') or entry.get('filename')
+                self.listbox.insert(END, name)
+            self.status.config(text=f"Loaded {len(entries)} entries")
+        except Exception as exc:
+            self.status.config(text=f"Error: {exc}")
+
+
+if __name__ == '__main__':
+    app = App()
+    app.mainloop()

--- a/desktop_app/requirements.txt
+++ b/desktop_app/requirements.txt
@@ -1,0 +1,2 @@
+requests
+Pillow


### PR DESCRIPTION
## Summary
- start basic Tkinter desktop client
- allow configuration of API base URL
- add helper module for REST requests
- add requirements and readme
- ignore server code and caches

## Testing
- `python -m py_compile desktop_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685d7b551210833394581f34b1cd0cf5