### PR TITLE
Improve desktop UI design

### DIFF
--- a/desktop_app/README.md
+++ b/desktop_app/README.md
@@ -1,8 +1,7 @@
 # MyLoRA Desktop Client
 
 This folder contains a Tkinter based client for interacting with the MyLoRA REST API.
-The application now uses a dark themed grid interface similar to the MyLora web
-gallery.
+The application now uses a dark themed grid interface inspired by the MyLora web gallery. Grid items display the preview with the file name overlaid at the bottom and the download action uses an accent coloured button.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- refine dark mode theme to use accent color
- show overlay text on thumbnails
- enlarge preview sizes
- tweak download button style
- document the new appearance in the desktop README

## Testing
- `python -m py_compile desktop_app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685d7fbee760833384b40a8a1db43e35