### PR TITLE
Add detailed LoRA view

### DIFF
--- a/desktop_app/requirements.txt
+++ b/desktop_app/requirements.txt
@@ -1,2 +1,3 @@
 requests
 Pillow
+safetensors


### PR DESCRIPTION
## Summary
- add `safetensors` dependency
- enhance `api` wrapper with helpers for listing previews and reading metadata
- extend Tkinter detail window to show all previews and metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d81b158ac833393a8ccfd26286367