### PR TITLE
Fix crash when closing detail window

### DIFF
--- a/desktop_app/main.py
+++ b/desktop_app/main.py
@@ -230,6 +230,9 @@ class DetailWindow(Toplevel):
         self.after(0, lambda: self._populate(previews, metadata))
 
     def _populate(self, previews: list[str], metadata: dict):
+        if not self.meta_frame.winfo_exists():
+            return
+
         self.photos = []
         if previews:
             for url in previews:


### PR DESCRIPTION
## Summary
- avoid creating widgets if detail window already closed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d83206c84833380a7198bd1139bd5